### PR TITLE
use function arrays instead of preexec() and precmd() variables

### DIFF
--- a/bash-timer.sh
+++ b/bash-timer.sh
@@ -49,7 +49,7 @@ human_time()
   echo $s
 }
 
-preexec() {
+bashtimer_preexec() {
   # Thanks to /u/OneTurnMore
   # https://www.reddit.com/r/bash/comments/ivz276/tired_of_typing_time_all_the_time_try_bashtimer/g5wui2l/
   if [ ! -z "$EPOCHREALTIME" ]; then
@@ -62,7 +62,7 @@ preexec() {
   timer_show="0"
 }
 
-precmd() {
+bashtimer_precmd() {
   if [ ! -z "$begin_ns" ]; then
     local s
     local ms
@@ -112,3 +112,7 @@ precmd() {
   fi
 }
 
+## Using `bash-preexec` functions arrays makes this script compatible with other scripts that use `bash-preexec`.
+## It avoids overwriting variables `preexec` and `precmd`. 
+preexec_functions+=(bashtimer_preexec)
+precmd_functions+=(bashtimer_precmd)


### PR DESCRIPTION
Other scripts such as [undistract me](https://github.com/jml/undistract-me) also use bash-preexec. In the current situation, `bash-timer` and `undistract me` are incompatible, because they both define the `preexec` and `precmd` variables. Whichever gets sourced last overwrites the other, and gets executed.

To avoid this situation, `bash-preexec` offers function arrays `preexec_functions` and `precmd_functions` [(README)](https://github.com/rcaloras/bash-preexec#function-arrays), where one can append then functions that he wants executed for either hooks. 

Using this feature makes `bash- timer` compatible with other scripts such as [undistract me](https://github.com/jml/undistract-me).

----

I made the following modifications and tested them on my machine. Could you consider merging this in ? Let me know if I can help with more info, testing or other.