### PR TITLE
Fix locales with commas in $EPOCHREALTIME and occasional failures

### DIFF
--- a/bash-timer.sh
+++ b/bash-timer.sh
@@ -92,13 +92,13 @@ bashtimer_precmd() {
       end_ns=${_EPOCHREALTIME#*.}
       end_ns="${end_ns#0}"
 
+      # Convert strings with leading zeros to base 10 integers
+      begin_ns=$((10#$begin_ns))
+      end_ns=$((10#$end_ns))
       if [ $end_ns -lt $begin_ns ]; then
         end_ns=$((1000000 + $end_ns))
         end_s=$(($end_s - 1))
       fi
-      # Convert strings with leading zeros to base 10 integers
-      begin_ns=$((10#$begin_ns))
-      end_ns=$((10#$end_ns))
 
       s=$((end_s - begin_s))
       if [ "$end_ns" -ge "$begin_ns" ]; then

--- a/bash-timer.sh
+++ b/bash-timer.sh
@@ -63,10 +63,10 @@ bashtimer_preexec() {
   # https://www.reddit.com/r/bash/comments/ivz276/tired_of_typing_time_all_the_time_try_bashtimer/g5wui2l/
   if [ ! -z "$EPOCHREALTIME" ]; then
     # Replace "," decimal separator with ".". This is needed for European locales, among others.
-    EPOCHREALTIME="${EPOCHREALTIME/,/.}"
+    local _EPOCHREALTIME="${EPOCHREALTIME/,/.}"
 
-    begin_s=${EPOCHREALTIME%.*}
-    begin_ns=${EPOCHREALTIME#*.}
+    begin_s=${_EPOCHREALTIME%.*}
+    begin_ns=${_EPOCHREALTIME#*.}
     begin_ns="${begin_ns#0}"
   else
     read begin_s begin_ns <<< $(date +"%s %N")
@@ -85,11 +85,11 @@ bashtimer_precmd() {
     # https://www.reddit.com/r/bash/comments/ivz276/tired_of_typing_time_all_the_time_try_bashtimer/g5wui2l/
     if [ ! -z "$EPOCHREALTIME" ]; then
       # Replace "," decimal separator with ".". This is needed for European locales, among others.
-      EPOCHREALTIME="${EPOCHREALTIME/,/.}"
+      local _EPOCHREALTIME="${EPOCHREALTIME/,/.}"
 
-      end_s=${EPOCHREALTIME%.*}
+      end_s=${_EPOCHREALTIME%.*}
       # echo "Begin Seconds: $begin_s | End Seconds: $end_s"
-      end_ns=${EPOCHREALTIME#*.}
+      end_ns=${_EPOCHREALTIME#*.}
       end_ns="${end_ns#0}"
 
       if [ $end_ns -lt $begin_ns ]; then


### PR DESCRIPTION
Sorry the history is a bit messy, I'm on a computer without github tokens and of course I thought it would be faster to just write in the browser than generating one...

Anyway...
1. the $EPOCHREALTIME fix was borked because that's a readonly variable - fixed
2. erasing only one leading zero didn't always work, with eg 1234.008 you'll get "008" milliseconds, which becomes "08", which makes bash error out attempting to treat it as an octal number - fixed

Let me know if there's any issue (other than 3 commits instead of 2 :)

Edit: fixed the above, now it's no longer hideous to look at